### PR TITLE
Workaround to get Merge_Log working with native cri parser

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,6 +37,11 @@ data:
 
   filter-kubernetes.conf: |
     [FILTER]
+        Name    modify
+        Match   kube.*
+        Rename  message log
+  
+    [FILTER]
         Name                kubernetes
         Match               kube.*
         Kube_URL            https://kubernetes.default.svc:443
@@ -81,7 +86,7 @@ data:
         Time_Keep Off
 
     [PARSER]
-        Name        cri
+        Name        cri-log
         Format      regex
         Regex       ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$
         Time_Key    time


### PR DESCRIPTION
The current custom cri parser stores app logs with some log info (timestamp, log type...) plus the json log. This is a problem for Merge_Log, which only works when the "log" field contains only json format log. The native cri parser stores the json log in a valid way, the problem is that it's stored in the "message" field, and now the problem is that is that Merge_Log only parses the log field.

References: https://github.com/microsoft/fluentbit-containerd-cri-o-json-log/issues/4
